### PR TITLE
Fix filter for CentOS 7 in .bonsai.yml

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -34,7 +34,7 @@ builds:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
   -  "entity.system.platform_family == 'rhel'"
-  -  "entity.system.platform_release.split('.')[0] == '7'"
+  -  "entity.system.platform_version.split('.')[0] == '7'"
 - platform: "debian"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_debian_linux_amd64.tar.gz"


### PR DESCRIPTION
When "entitiy.system.platform_release" is used as a filter for CentOS7,
an error occurs:
"TypeError: Cannot access member 'split' of undefined"

So we use "platform_version".

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass
